### PR TITLE
Removed conflict, removed SetPartial

### DIFF
--- a/aws/resource_aws_lightsail_domain_test.go
+++ b/aws/resource_aws_lightsail_domain_test.go
@@ -44,7 +44,7 @@ func TestAccAWSLightsailDomain_disappears(t *testing.T) {
 		})
 
 		if err != nil {
-			return fmt.Errorf("Error deleting Lightsail Domain in disappear test")
+			return fmt.Errorf("Error deleting Lightsail Domain in disapear test")
 		}
 
 		return nil

--- a/aws/resource_aws_lightsail_load_balancer.go
+++ b/aws/resource_aws_lightsail_load_balancer.go
@@ -141,6 +141,7 @@ func resourceAwsLightsailLoadBalancerRead(d *schema.ResourceData, meta interface
 	d.Set("name", resp.LoadBalancer.Name)
 	d.Set("protocol", resp.LoadBalancer.Protocol)
 	d.Set("public_ports", resp.LoadBalancer.PublicPorts)
+	d.Set("dns_name", resp.LoadBalancer.DnsName)
 
 	if err := d.Set("tags", keyvaluetags.LightsailKeyValueTags(resp.LoadBalancer.Tags).IgnoreAws().Map()); err != nil {
 		return fmt.Errorf("error setting tags: %s", err)
@@ -189,7 +190,7 @@ func resourceAwsLightsailLoadBalancerUpdate(d *schema.ResourceData, meta interfa
 			AttributeValue:   aws.String(d.Get("health_check_path").(string)),
 			LoadBalancerName: aws.String(d.Get("name").(string)),
 		})
-		d.SetPartial("health_check_path")
+		d.Set("health_check_path", d.Get("health_check_path").(string))
 		if err != nil {
 			return err
 		}

--- a/aws/resource_aws_lightsail_load_balancer_test.go
+++ b/aws/resource_aws_lightsail_load_balancer_test.go
@@ -88,6 +88,7 @@ func TestAccAWSLightsailLoadBalancer_basic(t *testing.T) {
 					testAccCheckAWSLightsailLoadBalancerExists("aws_lightsail_load_balancer.lightsail_load_balancer_test", &loadBalancer),
 					resource.TestCheckResourceAttrSet("aws_lightsail_load_balancer.lightsail_load_balancer_test", "health_check_path"),
 					resource.TestCheckResourceAttrSet("aws_lightsail_load_balancer.lightsail_load_balancer_test", "instance_port"),
+					resource.TestCheckResourceAttrSet("aws_lightsail_load_balancer.lightsail_load_balancer_test", "dns_name"),
 					resource.TestCheckResourceAttr("aws_lightsail_load_balancer.lightsail_load_balancer_test", "tags.%", "0"),
 				),
 			},
@@ -271,7 +272,6 @@ func testAccAWSLightsailLoadBalancerConfig_basic(lightsailLoadBalancerName strin
 provider "aws" {
   region = "us-east-1"
 }
-
 resource "aws_lightsail_load_balancer" "lightsail_load_balancer_test" {
   name               = "%s"
   health_check_path  = "/"
@@ -285,7 +285,6 @@ func testAccAWSLightsailLoadBalancerConfig_tags1(lightsailLoadBalancerName strin
 provider "aws" {
   region = "us-east-1"
 }
-
 resource "aws_lightsail_load_balancer" "lightsail_load_balancer_test" {
   name               = "%s"
   health_check_path  = "/"
@@ -302,7 +301,6 @@ func testAccAWSLightsailLoadBalancerConfig_tags2(lightsailLoadBalancerName strin
 provider "aws" {
   region = "us-east-1"
 }
-
 resource "aws_lightsail_load_balancer" "lightsail_load_balancer_test" {
   name               = "%s"
   health_check_path  = "/"


### PR DESCRIPTION
* This Spelling error is already resolved in the main branch and this change is causing a conflict.
* The helper/schema.ResourceData.SetPartial method was deprecated and has been removed.
* added dns_name to the read function to set the value in state